### PR TITLE
chore: pin GitHub Actions to commit hashes and add pinact check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '22'
         cache: 'npm'

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,21 @@
+name: Check Pinned Actions
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  check-pinned-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Check GitHub Actions are pinned to commit hashes
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+          verify: "true"


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` and `actions/setup-node` in `ci.yml` to commit hashes
- Add `pinact.yml` to continuously verify that all Actions are pinned to commit hashes on every PR and push to `master`

## Changes

- `.github/workflows/ci.yml`: Replace version tags with commit hashes
  - `actions/checkout@v5` → `@93cb6efe...` (v5.0.1)
  - `actions/setup-node@v6` → `@48b55a01...` (v6.4.0)
- `.github/workflows/pinact.yml`: Add new workflow using `suzuki-shunsuke/pinact-action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)